### PR TITLE
Keep a proper stack of inner items during demangling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,7 @@ fn test_afl_seed_{}() {{
 // Ratcheting number that is increased as more libiberty tests start
 // passing. Once they are all passing, this can be removed and we can enable all
 // of them by default.
-const LIBIBERTY_TEST_THRESHOLD: usize = 48;
+const LIBIBERTY_TEST_THRESHOLD: usize = 49;
 
 /// Read `tests/libiberty-demangle-expected`, parse its input mangled symbols,
 /// and expected output demangled symbols, and generate test cases for them.
@@ -159,8 +159,8 @@ fn test_libiberty_demangle_{}_() {{
         .expect("should parse mangled symbol");
 
     let expected = r#"{}"#;
-    println!("     Expect demangled symbol: {{}}", expected);
     let actual = format!("{{}}", sym);
+    println!("     Expect demangled symbol: {{}}", expected);
     println!("Actually demangled symbol as: {{}}", actual);
 
     assert_eq!(expected, actual);

--- a/src/bin/cppfilt.rs
+++ b/src/bin/cppfilt.rs
@@ -1,3 +1,6 @@
+// For clippy.
+#![allow(unknown_lints)]
+
 extern crate cpp_demangle;
 
 use cpp_demangle::BorrowedSymbol;
@@ -6,6 +9,7 @@ use std::process;
 
 /// Find the index of the first (potential) occurrence of a mangled C++ symbol
 /// in the given `haystack`.
+#[allow(needless_range_loop)]
 fn find_mangled(haystack: &[u8]) -> Option<usize> {
     for i in 0..haystack.len() - 1 {
         if haystack[i] == b'_' {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,10 @@
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_code)]
 
+// Clippy stuff.
+#![allow(unknown_lints)]
+#![allow(inline_always)]
+
 #[macro_use]
 mod logging;
 


### PR DESCRIPTION
I was hoping to avoid this, but it doesn't seem like that is possible. This
replaces the `DemangleWithInner` trait with a stack of inner items for
demangling on the context. This required a ton of lifetime wrangling to
compile. We now statically distinguish between demangling as an outer
item (Demangle::demangle) vs demangling in an inner
position (DemangleAsInner::demangle_as_inner).

Additionally, this adds logging during demangling when the logging feature is
enabled.