### PR TITLE
Demangle multidimensional arrays correctly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,7 @@ fn test_afl_seed_{}() {{
 // Ratcheting number that is increased as more libiberty tests start
 // passing. Once they are all passing, this can be removed and we can enable all
 // of them by default.
-const LIBIBERTY_TEST_THRESHOLD: usize = 52;
+const LIBIBERTY_TEST_THRESHOLD: usize = 58;
 
 /// Read `tests/libiberty-demangle-expected`, parse its input mangled symbols,
 /// and expected output demangled symbols, and generate test cases for them.


### PR DESCRIPTION
Inner types for multidimensional arrays should not be wrapped in parentheses or
have spaces after them, eg `int [][]` rather than `int ([]) []`.