### PR TITLE
#70 *should add --help and --version using clap to the cppflit clone example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ travis-ci = { repository = "fitzgen/cpp_demangle" }
 
 [dependencies]
 fixedbitset = "0.1.5"
+clap = "2.20.5"
 
 [dependencies.afl]
 optional = true

--- a/src/bin/cppfilt.rs
+++ b/src/bin/cppfilt.rs
@@ -3,9 +3,14 @@
 
 extern crate cpp_demangle;
 
+// For command line integration
+#[macro_use]
+extern crate clap;
+
 use cpp_demangle::BorrowedSymbol;
 use std::io::{self, BufRead, Write};
 use std::process;
+use clap::App;
 
 /// Find the index of the first (potential) occurrence of a mangled C++ symbol
 /// in the given `haystack`.
@@ -62,6 +67,13 @@ fn demangle_all<R, W>(input: &mut R, out: &mut W) -> io::Result<()>
 }
 
 fn main() {
+    let _ = App::new("cppfilt")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("A c++filt clone as an example of how to use the cpp_demangle crate!")
+        .get_matches();
+
+    
     let stdin = io::stdin();
     let mut stdin = stdin.lock();
 


### PR DESCRIPTION
This should resolve #70. Please let me know if need to make any changes!

Side Note: I ran cargo fmt and it touched a BUNCH of files but none of them ones I had edited so I didn't commit any of that.