### PR TITLE
Update links to the Itanium C++ ABI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ declarations can pair up definitions in one unit with references in another.
 Almost all platforms other than Microsoft Windows follow the
 [Itanium C++ ABI][itanium]'s rules for this.
 
-[itanium]: http://mentorembedded.github.io/cxx-abi/abi.html#mangling
+[itanium]: http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle
 
 For example, suppose a C++ compilation unit has the definition:
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -884,7 +884,7 @@ impl<'subs, W> Demangle<'subs, W> for Encoding
                 // whether this is a template.
                 //
                 // For the details, see
-                // http://mentorembedded.github.io/cxx-abi/abi.html#mangle.function-type
+                // http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.function-type
                 let stack = if let Some(template_args) = name.get_template_args(ctx.subs) {
                     let stack = stack.push(template_args);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! another.  Almost all platforms other than Microsoft Windows follow the
 //! [Itanium C++ ABI][itanium]'s rules for this.
 //!
-//! [itanium]: http://mentorembedded.github.io/cxx-abi/abi.html#mangling
+//! [itanium]: http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle
 //!
 //! For example, suppose a C++ compilation unit has the definition:
 //!


### PR DESCRIPTION
The specification for the ABI changed URLs without leaving a redirect behind.