### PR TITLE
Fix cast operators and template args

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,7 @@ fn test_afl_seed_{}() {{
 // Ratcheting number that is increased as more libiberty tests start
 // passing. Once they are all passing, this can be removed and we can enable all
 // of them by default.
-const LIBIBERTY_TEST_THRESHOLD: usize = 58;
+const LIBIBERTY_TEST_THRESHOLD: usize = 59;
 
 /// Read `tests/libiberty-demangle-expected`, parse its input mangled symbols,
 /// and expected output demangled symbols, and generate test cases for them.


### PR DESCRIPTION
Cast operators can refer to template arguments that don't get defined until
further down the AST, so we have to traverse down and fetch them.