### PR TITLE
Only build the `cppfilt` clone if a feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,15 @@ version = "0.2.2"
 [badges.travis-ci]
 repository = "fitzgen/cpp_demangle"
 
+[[bin]]
+name = "cppfilt"
+path = "src/bin/cppfilt.rs"
+required-features = ["cppfilt"]
+
 [build-dependencies]
 glob = "0.2.11"
 
 [dependencies]
-clap = "2.20.5"
 fixedbitset = "0.1.5"
 
 [dependencies.afl]
@@ -31,13 +35,31 @@ version = "0.1.5"
 optional = true
 version = "0.1.5"
 
+[dependencies.clap]
+optional = true
+version = "2.24.2"
+
 [dev-dependencies]
 diff = "0.1.10"
 
 [features]
+# Build the `c++filt` clone executable.
+cppfilt = ["clap"]
+
+# Default features.
+default = ["cppfilt"]
+
+# Build with support for fuzzing with AFL.rs.
 fuzz = ["afl", "afl-plugin"]
+
+# Enable copious amounts of logging. Only useful for hacking on `cpp_demangle`
+# itself.
 logging = []
+
+# Enable nightly-only features for testing, clippy, etc.
 nightly = []
+
+# Run all libiberty tests, even the ones that are known not to pass yet.
 run_libiberty_tests = []
 
 [profile]


### PR DESCRIPTION
This commit adds a new `cppfilt` feature to control if the `cppfilt` executable is built or not. It is on by default.

Fixes #82 on the `cpp_demangle` side, but `backtrace-rs` will need a PR to disable default features.