### PR TITLE
A variety of improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ required-features = ["cppfilt"]
 [build-dependencies]
 glob = "0.2.11"
 
-[dependencies]
-fixedbitset = "0.1.5"
-
 [dependencies.afl]
 optional = true
 version = "0.1.5"

--- a/build.rs
+++ b/build.rs
@@ -97,7 +97,7 @@ fn test_afl_seed_{}() {{
 // Ratcheting number that is increased as more libiberty tests start
 // passing. Once they are all passing, this can be removed and we can enable all
 // of them by default.
-const LIBIBERTY_TEST_THRESHOLD: usize = 61;
+const LIBIBERTY_TEST_THRESHOLD: usize = 65;
 
 /// Read `tests/libiberty-demangle-expected`, parse its input mangled symbols,
 /// and expected output demangled symbols, and generate test cases for them.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2770,7 +2770,7 @@ where
 impl GetTemplateArgs for Type {
     fn get_template_args<'a>(
         &'a self,
-        _subs: &'a SubstitutionTable,
+        subs: &'a SubstitutionTable,
     ) -> Option<&'a TemplateArgs> {
         // TODO: This should probably recurse through all the nested type
         // handles too.
@@ -2778,6 +2778,9 @@ impl GetTemplateArgs for Type {
         match *self {
             Type::VendorExtension(_, Some(ref args), _) |
             Type::TemplateTemplate(_, ref args) => Some(args),
+            Type::PointerTo(ref ty) |
+            Type::LvalueRef(ref ty) |
+            Type::RvalueRef(ref ty) => ty.get_template_args(subs),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,10 +28,6 @@ pub enum Error {
     /// mangled symbol.
     Overflow,
 
-    /// The act of demangling some part of the AST attempted to demangle itself
-    /// again.
-    RecursiveDemangling,
-
     /// Encountered too much recursion when demangling symbol.
     TooMuchRecursion,
 }
@@ -57,10 +53,6 @@ impl fmt::Display for Error {
                 f,
                 "an overflow or underflow would occur when parsing an integer in a mangled symbol"
             ),
-            Error::RecursiveDemangling => write!(
-                f,
-                "demangling some part of the AST attempted to demangle itself again"
-            ),
             Error::TooMuchRecursion => {
                 write!(f, "encountered too much recursion when demangling symbol")
             }
@@ -84,9 +76,6 @@ impl error::Error for Error {
             }
             Error::Overflow => {
                 "an overflow or underflow would occur when parsing an integer in a mangled symbol"
-            }
-            Error::RecursiveDemangling => {
-                "demangling some part of the AST attempted to demangle itself again"
             }
             Error::TooMuchRecursion => {
                 "encountered too much recursion when demangling symbol"

--- a/src/index_str.rs
+++ b/src/index_str.rs
@@ -47,6 +47,12 @@ impl<'a> IndexStr<'a> {
         self.as_ref().get(0).cloned()
     }
 
+    /// Peek at the second next byte in this `IndexStr`.
+    #[inline]
+    pub fn peek_second(&self) -> Option<u8> {
+        self.as_ref().get(1).cloned()
+    }
+
     /// Split the string in two at the given index, resulting in the tuple where
     /// the first item has range `[0, idx)`, and the second has range `[idx,
     /// len)`.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -100,6 +100,7 @@ demangles!(
     _ZN2Ty6methodIS_EEvMT_FvPKcES5_,
     "void Ty::method<Ty>(void (Ty::*)(char const*), void (Ty::*)(char const*))"
 );
+demangles!(_ZNK1fB5cxx11Ev,"f[abi:cxx11]() const");
 
 // Test cases found via differential testing against `c++filt` with `cargo-fuzz`
 // and `libFuzzer`.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -101,6 +101,10 @@ demangles!(
     "void Ty::method<Ty>(void (Ty::*)(char const*), void (Ty::*)(char const*))"
 );
 demangles!(_ZNK1fB5cxx11Ev,"f[abi:cxx11]() const");
+demangles!(
+    _ZN4base8internal14CheckedSubImplIlEENSt9enable_ifIXsrSt14numeric_limitsIT_E10is_integerEbE4typeES4_S4_PS4_,
+    "std::enable_if<std::numeric_limits<long>::is_integer, bool>::type base::internal::CheckedSubImpl<long>(long, long, long*)"
+);
 
 // Test cases found via differential testing against `c++filt` with `cargo-fuzz`
 // and `libFuzzer`.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -105,6 +105,13 @@ demangles!(
     _ZN4base8internal14CheckedSubImplIlEENSt9enable_ifIXsrSt14numeric_limitsIT_E10is_integerEbE4typeES4_S4_PS4_,
     "std::enable_if<std::numeric_limits<long>::is_integer, bool>::type base::internal::CheckedSubImpl<long>(long, long, long*)"
 );
+demangles!(_ZZN7mozilla12EMEDecryptor5FlushEvENUlvE_D4Ev,
+           "mozilla::EMEDecryptor::Flush()::{lambda()#0}::maybe in-charge destructor()"
+);
+demangles!(
+    _ZSt4copyIPKcPcET0_T_S4_S3_,
+    "char* std::copy<char const*, char*>(char const*, char const*, char*)"
+);
 
 // Test cases found via differential testing against `c++filt` with `cargo-fuzz`
 // and `libFuzzer`.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -112,6 +112,7 @@ demangles!(
     _ZSt4copyIPKcPcET0_T_S4_S3_,
     "char* std::copy<char const*, char*>(char const*, char const*, char*)"
 );
+demangles!(_Z9_mm_or_psDv4_fS_, "_mm_or_ps(float __vector(4), float __vector(4))");
 
 // Test cases found via differential testing against `c++filt` with `cargo-fuzz`
 // and `libFuzzer`.


### PR DESCRIPTION
These patches combined get the number of symbols in all of Firefox's debug info that fail to parse down from ~175k to a little over 2k.  I think they're all self-explanatory or well documented enough in the commit message that I don't need to explain them in detail here.